### PR TITLE
Add scenario temperature setting

### DIFF
--- a/pkg/server/manager.go
+++ b/pkg/server/manager.go
@@ -71,6 +71,7 @@ type SimScenarioConfiguration struct {
 	PrimaryAirport      string
 
 	Wind         av.Wind
+	TemperatureC float32
 	LaunchConfig sim.LaunchConfig
 
 	DepartureRunways []sim.DepartureRunway
@@ -106,6 +107,8 @@ type NewSimConfiguration struct {
 	LiveWeather bool
 
 	GribFile string
+
+	TemperatureC float32
 
 	AllowInstructorRPO  bool
 	Instructor          bool
@@ -266,6 +269,7 @@ func (sm *SimManager) makeSimConfiguration(config *NewSimConfiguration, lg *log.
 		MagneticVariation:       sg.MagneticVariation,
 		NmPerLongitude:          sg.NmPerLongitude,
 		Wind:                    sc.Wind,
+		TemperatureC:            sc.TemperatureC,
 		Airports:                sg.Airports,
 		Fixes:                   sg.Fixes,
 		PrimaryAirport:          sg.PrimaryAirport,

--- a/pkg/server/scenario.go
+++ b/pkg/server/scenario.go
@@ -72,6 +72,7 @@ type scenario struct {
 	Range        float32       `json:"range"`
 	DefaultMaps  []string      `json:"default_maps"`
 	VFRRateScale *float32      `json:"vfr_rate_scale"`
+	TemperatureC *float32      `json:"temperature_c"`
 
 	GribFile string `json:"grib_file,omitempty"`
 }
@@ -565,6 +566,10 @@ func (s *scenario) PostDeserialize(sg *scenarioGroup, e *util.ErrorLogger, manif
 	if s.VFRRateScale == nil { // unspecified -> default to 1
 		one := float32(1)
 		s.VFRRateScale = &one
+	}
+	if s.TemperatureC == nil {
+		std := float32(15)
+		s.TemperatureC = &std
 	}
 }
 
@@ -1351,6 +1356,7 @@ func initializeSimConfigurations(sg *scenarioGroup,
 			SplitConfigurations: scenario.SplitConfigurations,
 			LaunchConfig:        lc,
 			Wind:                scenario.Wind,
+			TemperatureC:        *scenario.TemperatureC,
 			DepartureRunways:    scenario.DepartureRunways,
 			ArrivalRunways:      scenario.ArrivalRunways,
 			PrimaryAirport:      sg.PrimaryAirport,

--- a/pkg/sim/spawn.go
+++ b/pkg/sim/spawn.go
@@ -1093,6 +1093,7 @@ func (s *Sim) createArrivalNoLock(group string, arrivalAirport string) (*Aircraf
 	if err != nil {
 		return nil, err
 	}
+	ac.Nav.Perf = s.scalePerformance(ac.Nav.Perf)
 
 	starsFp := STARSFlightPlan{
 		ACID:             ACID(ac.ADSBCallsign),
@@ -1256,6 +1257,7 @@ func (s *Sim) createIFRDepartureNoLock(departureAirport, runway, category string
 	if err != nil {
 		return nil, err
 	}
+	ac.Nav.Perf = s.scalePerformance(ac.Nav.Perf)
 
 	shortExit, _, _ := strings.Cut(dep.Exit, ".") // chop any excess
 	starsFp := STARSFlightPlan{
@@ -1344,6 +1346,7 @@ func (s *Sim) createOverflightNoLock(group string) (*Aircraft, error) {
 		s.State /* wind */, s.State.SimTime, s.lg); err != nil {
 		return nil, err
 	}
+	ac.Nav.Perf = s.scalePerformance(ac.Nav.Perf)
 
 	starsFp := STARSFlightPlan{
 		ACID:             ACID(ac.ADSBCallsign),
@@ -1538,6 +1541,7 @@ func (s *Sim) createUncontrolledVFRDeparture(depart, arrive, fleet string, route
 		s.State.NmPerLongitude, s.State.MagneticVariation, s.State /* wind */, s.lg); err != nil {
 		return nil, "", err
 	}
+	ac.Nav.Perf = s.scalePerformance(ac.Nav.Perf)
 
 	if s.bravoAirspace == nil || s.charlieAirspace == nil {
 		s.initializeAirspaceGrids()

--- a/pkg/sim/state.go
+++ b/pkg/sim/state.go
@@ -74,9 +74,10 @@ type State struct {
 	NmPerLongitude    float32
 	PrimaryAirport    string
 
-	METAR    map[string]*av.METAR
-	Wind     av.Wind
-	GribWind *av.GribWindModel
+	METAR        map[string]*av.METAR
+	Wind         av.Wind
+	TemperatureC float32
+	GribWind     *av.GribWindModel
 
 	TotalIFR, TotalVFR int
 
@@ -137,9 +138,10 @@ func newState(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Lo
 		NmPerLongitude:    config.NmPerLongitude,
 		PrimaryAirport:    config.PrimaryAirport,
 
-		METAR:    make(map[string]*av.METAR),
-		Wind:     config.Wind,
-		GribWind: nil,
+		METAR:        make(map[string]*av.METAR),
+		Wind:         config.Wind,
+		TemperatureC: config.TemperatureC,
+		GribWind:     nil,
 
 		SimRate:        1,
 		SimDescription: config.Description,


### PR DESCRIPTION
## Summary
- support scenario-level `temperature_c` field
- propagate temperature value through server configs to sim state
- scale climb/descent rates based on temperature and engine type

## Testing
- `go test ./...` *(fails: access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a320e4e648326b8169cd3710a78ff